### PR TITLE
WIP: Refactor into a linter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,3 +32,4 @@ install:
 
 script:
   - ember try $EMBER_TRY_SCENARIO test
+  - npm run test-node

--- a/README.md
+++ b/README.md
@@ -2,12 +2,35 @@
 
 [![Build Status](https://travis-ci.org/rwjblue/ember-cli-template-lint.svg?branch=master)](https://travis-ci.org/rwjblue/ember-cli-template-lint)
 
-This addon allows you to move template compilation deprecations into browser deprecations. This is useful if you would like to use the `ember-cli-deprecation-workflow` addon or just to throw errors on template compilation deprecations (via `EmberENV.RAISE_ON_DEPRECATE` flag).
+To install ember-cli-template-lint
+
+```
+ember install ember-cli-template-lint
+```
+
+Once installed, ember-cli-template-lint will add one test for each template
+in an 
+application's codebase, and assert that all style rules are fulfilled. For example, given
+the rule `bare-strings` is enabled, this template would be in violation:
+
+```hbs
+{{! app/components/my-thing/template.hbs }}
+<div>A bare string</div>
+```
+
+Thus a the test `TemplateLint: app/components/my-thing/template.hbs` would
+fail with the assertion "A bare string was found (0:5)".
+
+This addon also allows you to move template compilation deprecations into browser
+deprecations. This is useful if you would like to use the
+`ember-cli-deprecation-workflow` addon or just to throw errors on template
+compilation deprecations (via `EmberENV.RAISE_ON_DEPRECATE` flag).
 
 ## Configuration
 
-By default, the console based deprecations are suppressed in favor of browser deprecations ran during the test suite.  If you would prefer to still have the deprecations in the console, add
-the following to your `config/environment.js`:
+By default, the console based deprecations are suppressed in favor of browser
+deprecations ran during the test suite. If you would prefer to still have the
+deprecations in the console, add the following to your `config/environment.js`:
 
 ```javascript
 module.exports = function(env) {
@@ -20,6 +43,13 @@ module.exports = function(env) {
 ```
 
 ## Contributing
+
+A few ideas for where to take this in the future:
+
+* The list of rules should be configurable
+* This addon should use a test printer shared with jshint, eslint and jscs addons 
+* A command-line version of the linter should be provided so IDEs and editors
+  can provide feedback to devs during development
 
 ### Installation
 

--- a/ext/plugins/index.js
+++ b/ext/plugins/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  'bare-strings': require('./lint-bare-strings')
+};

--- a/ext/plugins/lint-bare-strings.js
+++ b/ext/plugins/lint-bare-strings.js
@@ -1,0 +1,55 @@
+// copied from emberjs/ember.js packages/ember-template-compiler/lib/system/calculate-location-display.js
+function calculateLocationDisplay(moduleName, _loc) {
+  var loc = _loc || {};
+  var start = loc.start || {};
+  var column = start.column;
+  var line = start.line;
+  var moduleInfo = '';
+  if (moduleName) {
+    moduleInfo +=  "'"+moduleName+"'";
+  }
+
+  if (line !== undefined && column !== undefined) {
+    if (moduleName) {
+      // only prepend @ if the moduleName was present
+      moduleInfo += '@ ';
+    }
+    moduleInfo += `L${line}:C${column}`;
+  }
+
+  if (moduleInfo) {
+    moduleInfo = `(${moduleInfo})`;
+  }
+
+  return moduleInfo;
+}
+
+function LogStaticStrings(options) {
+  this.options = options;
+  this.syntax = null; // set by HTMLBars
+}
+
+LogStaticStrings.prototype.transform = function(ast) {
+  var pluginContext = this;
+  var walker = new this.syntax.Walker();
+
+  walker.visit(ast, function(node) {
+    if (pluginContext.detectStaticString(node)) {
+      return pluginContext.processStaticString(node);
+    }
+  });
+
+  return ast;
+};
+
+LogStaticStrings.prototype.processStaticString = function(node) { 
+  var locationDisplay = calculateLocationDisplay(this.options.moduleName, node.loc);
+
+  throw new Error(`Non-translated string used ${locationDisplay} \`${node.chars}\``);
+}
+
+LogStaticStrings.prototype.detectStaticString = function(node) {  
+  return node.type === 'TextNode' && !node.raw && node.chars.trim() !== '';
+};
+
+module.exports = LogStaticStrings;

--- a/index.js
+++ b/index.js
@@ -53,6 +53,14 @@ module.exports = {
 
       this._monkeyPatch_EmberDeprecate(htmlbarsCompilerPreprocessor);
     }
+
+    var plugins = require('./ext/plugins');
+    for (var name in plugins) {
+      registry.add('htmlbars-ast-plugin', {
+        name: name,
+        plugin: plugins[name]
+      });
+    }
   },
 
   init: function() {

--- a/node-tests/helpers/template-compiler.js
+++ b/node-tests/helpers/template-compiler.js
@@ -1,0 +1,19 @@
+var path = require('path');
+var templateCompilerPath = path.join(__dirname, '../../bower_components/ember/ember-template-compiler');
+
+module.exports = function() {
+  var compiler = require(templateCompilerPath);
+
+  // ensure we get a fresh templateCompilerModuleInstance per ember-addon
+  // instance NOTE: this is a quick hack, and will only work as long as
+  // templateCompilerPath is a single file bundle
+  //
+  // (╯°□°）╯︵ ɹǝqɯǝ
+  //
+  // we will also fix this in ember for future releases
+  delete require.cache[templateCompilerPath];
+  delete global.Ember;
+  delete global.EmberENV;
+
+  return compiler;
+}

--- a/node-tests/nodetest-runner.js
+++ b/node-tests/nodetest-runner.js
@@ -1,0 +1,74 @@
+'use strict';
+
+var glob = require('glob');
+var Mocha = require('mocha');
+var Promise = require('ember-cli/lib/ext/promise');
+var rimraf = require('rimraf');
+var mochaOnlyDetector = require('mocha-only-detector');
+
+if (process.env.EOLNEWLINE) {
+  require('os').EOL = '\n';
+}
+
+rimraf.sync('.node_modules-tmp');
+rimraf.sync('.bower_components-tmp');
+
+var root = 'node-tests/{blueprints,acceptance,unit}';
+var _checkOnlyInTests = Promise.denodeify(mochaOnlyDetector.checkFolder.bind(null, root + '/**/*{-test}.js'));
+var optionOrFile = process.argv[2];
+var mocha = new Mocha({
+  timeout: 5000,
+  reporter: 'spec'
+});
+var testFiles = glob.sync(root + '/**/*-test.js');
+/*var jshintPosition = testFiles.indexOf('tests/unit/jshint-test.js');
+var jshint = testFiles.splice(jshintPosition, 1);
+
+testFiles = jshint.concat(testFiles);
+*/
+if (optionOrFile === 'all') {
+  addFiles(mocha, testFiles);
+  addFiles(mocha, 'node-tests/**/*-test.js');
+  addFiles(mocha, '/**/*-test-slow.js');
+} else if (process.argv.length > 2)  {
+  addFiles(mocha, process.argv.slice(2));
+} else {
+  addFiles(mocha, testFiles);
+}
+
+function addFiles(mocha, files) {
+  files = (typeof files === 'string') ? glob.sync(root + files) : files;
+  files.forEach(mocha.addFile.bind(mocha));
+}
+
+function checkOnlyInTests() {
+  console.log('Verifing `.only` in tests');
+  return _checkOnlyInTests().then(function() {
+    console.log('No `.only` found');
+  });
+}
+
+function runMocha() {
+  mocha.run(function(failures) {
+    process.on('exit', function() {
+      process.exit(failures);
+    });
+  });
+}
+
+function ciVerificationStep() {
+  if (process.env.CI === 'true') {
+    return checkOnlyInTests();
+  } else {
+    return Promise.resolve();
+  }
+}
+
+ciVerificationStep()
+  .then(function() {
+    runMocha();
+  })
+  .catch(function(error) {
+    console.error(error.stack);
+    process.exit(1);
+  });

--- a/node-tests/unit/linting-compiler-test.js
+++ b/node-tests/unit/linting-compiler-test.js
@@ -1,0 +1,39 @@
+var assert = require('assert');
+var buildTemplateCompiler = require('../helpers/template-compiler');
+var plugins = require('../../ext/plugins');
+
+describe('Ember template compiler', function() {
+
+  var templateCompiler;
+  beforeEach(function() {
+    templateCompiler = buildTemplateCompiler();
+  });
+
+  it('sanity: compiles templates', function() {
+    var template = templateCompiler.precompile('<div></div>');
+    assert.ok(template, 'template is created from precompile');
+  });
+
+  it('sanity: loads plugins on the template compiler', function() {
+    var instanceCount = 0;
+    var NoopPlugin = function(){
+      instanceCount++;
+    };
+    NoopPlugin.prototype.transform = function(ast) {
+      return ast;
+    };
+    templateCompiler.registerPlugin('ast', NoopPlugin);
+    var template = templateCompiler.precompile('<div></div>');
+    assert.equal(instanceCount, 1, 'registered plugins are instantiated');
+  });
+
+  it('can run a single template + rule', function() {
+    templateCompiler.registerPlugin('ast', plugins['bare-strings']);
+    assert.throws(function() {
+      templateCompiler.precompile('\n howdy', {
+        moduleName: 'layout.hbs'
+      });
+    }, /Non-translated string used.*layout\.hbs/m);
+  });
+
+});

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "build": "ember build",
     "start": "ember server",
-    "test": "ember try:testall"
+    "test": "ember try:testall",
+    "test-node": "node node-tests/nodetest-runner.js"
   },
   "homepage": "https://github.com/rwjblue/ember-cli-template-lint",
   "repository": {
@@ -41,7 +42,12 @@
     "ember-load-initializers": "^0.5.0",
     "ember-resolver": "^2.0.3",
     "ember-try": "^0.1.2",
-    "loader.js": "^4.0.0"
+    "glob": "^7.0.0",
+    "loader.js": "^4.0.0",
+    "mocha": "^2.4.5",
+    "mocha-only-detector": "^0.1.0",
+    "rimraf": "^2.5.2",
+    "vows": "^0.8.1"
   },
   "keywords": [
     "ember-addon"


### PR DESCRIPTION
TODO

* [ ] Coalesce multiple errors/failures into a single test failure
* [ ] Extract the `deprecate` monkey patches out (perhaps into `ember-cli-deprecation-workflow`?)
* [ ] Make what lint options are enabled configurable via `.template-lint-rc`
* [ ] Add an acceptance test to the dummy app