### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ ember install ember-cli-template-lint
 ```
 
 Once installed, ember-cli-template-lint will add one test for each template
-in an 
+in an
 application's codebase, and assert that all style rules are fulfilled. For example, given
 the rule `bare-strings` is enabled, this template would be in violation:
 
@@ -42,12 +42,24 @@ module.exports = function(env) {
 }
 ```
 
+Plugins are included by default. You can turn off plugins by toggling them in a
+`.template-lintrc` file at the base of your project:
+
+```javascript
+module.exports = {
+  'bare-strings': false
+}
+```
+
+## Plugins
+Checkout the `ext/plugins/index.js` for a list of all linting plugins.
+
 ## Contributing
 
 A few ideas for where to take this in the future:
 
 * The list of rules should be configurable
-* This addon should use a test printer shared with jshint, eslint and jscs addons 
+* This addon should use a test printer shared with jshint, eslint and jscs addons
 * A command-line version of the linter should be provided so IDEs and editors
   can provide feedback to devs during development
 

--- a/ext/plugins/lint-bare-strings.js
+++ b/ext/plugins/lint-bare-strings.js
@@ -1,3 +1,11 @@
+// Disallows the use of bare strings in a template
+//
+// passes:
+// <div>{{evaluatesToAString}}</div>
+//
+// breaks:
+// <div>A bare string</div>
+
 var calculateLocationDisplay = require('../helpers/calculate-location-display');
 
 module.exports = function(addonContext) {

--- a/ext/plugins/lint-block-indentation.js
+++ b/ext/plugins/lint-block-indentation.js
@@ -1,3 +1,13 @@
+// Forces block syntax to have appropriate indentation
+//
+// passes:
+// {{#each foo as |bar|}}
+// {{/each}}
+//
+// breaks:
+// {{#each foo as |bar|}}
+//  {{/each}}
+
 var calculateLocationDisplay = require('../helpers/calculate-location-display');
 
 module.exports = function(addonContext) {


### PR DESCRIPTION
Add explanation of `.template-lintrc` in the README. 
Add description of plugins at top of plugin. 

I added a description of the plugins at the top of each plugin. I thought about adding them to the README but if this addon ends up including many plugins that could become pretty unwieldy. ¯\\\_(ツ)_/¯

Question for purpose of general bike sheddery :bike:: 
Should there be a clean up around the semantics of rules vs. plugins? Seems like they are the same concept and it'd be cool if they were referenced in a single way in the README. I'd be happy to try and unify them if it is indeed an appropriate thing to do.