### PR TITLE
Detect and handle blocks nested inside inverse.

### DIFF
--- a/node-tests/helpers/rule-test-harness.js
+++ b/node-tests/helpers/rule-test-harness.js
@@ -38,7 +38,9 @@ module.exports = function(options) {
     });
 
     options.bad.forEach(function(badItem) {
-      it('logs a message in the console when given `' + badItem.template + '`', function() {
+      var testMethod = badItem.focus ? it.only : it;
+
+      testMethod('logs a message in the console when given `' + badItem.template + '`', function() {
         compile(badItem.template);
 
         assert.deepEqual(messages, [badItem.message]);

--- a/node-tests/unit/plugins/lint-block-indentation-test.js
+++ b/node-tests/unit/plugins/lint-block-indentation-test.js
@@ -8,7 +8,14 @@ generateRuleTests({
   good: [
     '\n  {{#each cats as |dog|}}\n  {{/each}}',
     '<div><p>Stuff</p></div>',
-    '<div>\n  <p>Stuff Here</p>\n</div>'
+    '<div>\n  <p>Stuff Here</p>\n</div>',
+    '{{#if isMorning}}' +
+    '  Good morning\n' +
+    '{{else if isAfternoon}}' +
+    '  Good afternoon\n' +
+    '{{else}}\n' +
+    '  Good night\n' +
+    '{{/if}}'
   ],
 
   bad: [
@@ -28,6 +35,16 @@ generateRuleTests({
       template: '<div>\n  <p>Stuff goes here</p></div>',
 
       message: "Incorrect indentation for `div` beginning at ('layout.hbs'@ L1:C0). Expected `</div>` ending at ('layout.hbs'@ L2:C30)to be at an indentation of 0 but was found at 24."
+    },
+    {
+      template: '{{#if isMorning}}\n' +
+        '{{else}}\n' +
+        '  {{#if something}}\n' +
+        '    Good night\n' +
+        '    {{/if}}\n' +
+        '{{/if}}',
+
+      message: "Incorrect indentation for `if` beginning at ('layout.hbs'@ L3:C2). Expected `{{/if}}` ending at ('layout.hbs'@ L5:C11)to be at an indentation of 2 but was found at 4."
     }
   ]
 });


### PR DESCRIPTION
Fixes #36.

Now works properly:

```hbs
{{#if isMorning}}
  Good morning
{{else if isAfternoon}}
  Good afternoon
{{else}}
  Good night
{{/if}}
```