### PR TITLE
Enable log messages on initial build when cached.

### DIFF
--- a/broccoli-template-linter.js
+++ b/broccoli-template-linter.js
@@ -74,8 +74,6 @@ TemplateLinter.prototype.cacheKeyProcessString = function(string, relativePath) 
 
 TemplateLinter.prototype.logLintingError = function(pluginName, moduleName, message) {
   this._queuedMessages.push(message);
-
-  this._console.log(chalk.yellow(message));
 };
 
 TemplateLinter.prototype.buildASTPlugins = function() {
@@ -104,7 +102,7 @@ TemplateLinter.prototype.processString = function(contents, relativePath) {
   var errors = '\n' + this._queuedMessages.join('\n');
   var passed = this._queuedMessages.length === 0;
 
-  return this._generateTestFile(
+  var output = this._generateTestFile(
     'TemplateLint - ' + relativePath,
     [{
       name: 'should pass TemplateLint',
@@ -112,6 +110,21 @@ TemplateLinter.prototype.processString = function(contents, relativePath) {
       errorMessage: relativePath + ' should pass TemplateLint.' + jsStringEscape(errors)
     }]
   );
+
+  return {
+    messages: this._queuedMessages,
+    output: output
+  };
+};
+
+TemplateLinter.prototype.postProcess = function(results) {
+  var messages = results.messages;
+
+  for (var i = 0; i < messages.length; i++) {
+    this._console.log(chalk.yellow(messages[i]));
+  }
+
+  return results;
 };
 
 module.exports = TemplateLinter;

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   ],
   "dependencies": {
     "broccoli-kitchen-sink-helpers": "^0.2.7",
-    "broccoli-persistent-filter": "^1.1.8",
+    "broccoli-persistent-filter": "^1.2.0",
     "chalk": "^1.1.1",
     "ember-cli-babel": "^5.1.5",
     "exists-sync": "0.0.3",


### PR DESCRIPTION
* Move logging into `postProcess`
* Return an object with `messages` and `output` from `processString`

---

Before:

```

% ember b && ember b
version: 2.4.2
Building..Non-translated string used ('sample-2-4-0/templates/application.hbs') `Welcome to Ember`
Built project successfully. Stored in "dist/".
version: 2.4.2
Built project successfully. Stored in "dist/".
```

After:

```
% ember b && ember b
version: 2.4.2
Building..Non-translated string used ('sample-2-4-0/templates/application.hbs') `Welcome to Ember`
Built project successfully. Stored in "dist/".
version: 2.4.2
Building..Non-translated string used ('sample-2-4-0/templates/application.hbs') `Welcome to Ember`
Built project successfully. Stored in "dist/".
```

Fixes https://github.com/rwjblue/ember-cli-template-lint/issues/34.