### PR TITLE
Add default whitelist for bare-strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ The following values are valid configuration:
 
   * boolean -- `true` for enabled / `false` for disabled
   * array -- an array of whitelisted strings
+  
+By default, the following characters are whitelisted: 
+`(),.&+-=*/#%!?:[]{}`
 
 
 #### block-indentation

--- a/blueprints/ember-cli-template-lint/files/.template-lintrc.js
+++ b/blueprints/ember-cli-template-lint/files/.template-lintrc.js
@@ -2,7 +2,7 @@
 'use strict';
 
 module.exports = {
-  'bare-strings': true,
+  'bare-strings': ['(', ')', ',', '.', '&', '+', '-', '=', '*', '/', '#', '%', '!', '?', ':', '[', ']', '{', '}'],
   'block-indentation': 2,
   'triple-curlies': true
 };

--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -10,7 +10,7 @@ function buildDefaultConfig(ui) {
                       'configuration.'));
 
   return {
-    'bare-strings': true,
+    'bare-strings': ['(', ')', ',', '.', '&', '+', '-', '=', '*', '/', '#', '%', '!', '?', ':', '[', ']', '{', '}'],
     'block-indentation': 2,
     'triple-curlies': true
   };

--- a/node-tests/unit/plugins/lint-bare-strings-test.js
+++ b/node-tests/unit/plugins/lint-bare-strings-test.js
@@ -34,6 +34,6 @@ generateRuleTests({
 
   bad: [
     { template: '\n howdy', message: "Non-translated string used (\'layout.hbs\') `\n howdy`" },
-    { template: '1234', message: "Non-translated string used (\'layout.hbs\') `1234`" },
+    { template: '1234', message: "Non-translated string used (\'layout.hbs\') `1234`" }
   ]
 });

--- a/node-tests/unit/plugins/lint-bare-strings-test.js
+++ b/node-tests/unit/plugins/lint-bare-strings-test.js
@@ -5,7 +5,7 @@ var generateRuleTests = require('../../helpers/rule-test-harness');
 generateRuleTests({
   name: 'bare-strings',
 
-  config: true,
+  config: ['(', ')', ',', '.', '&', '+', '-', '=', '*', '/', '#', '%', '!', '?', ':', '[', ']', '{', '}'],
 
   good: [
     '{{t "howdy"}}',
@@ -20,10 +20,20 @@ generateRuleTests({
     {
       config: ['/', '"'],
       template: '{{t "foo"}} / "{{name}}"'
+    },
+    {
+      template: '{{t "foo"}}'
+    },
+    {
+      template: '{{t "foo"}}, {{t "bar"}} ({{length}})'
+    },
+    {
+      template: '(),.&+-=*/#%!?:[]{}'
     }
   ],
 
   bad: [
-    { template: '\n howdy', message: "Non-translated string used (\'layout.hbs\') `\n howdy`" }
+    { template: '\n howdy', message: "Non-translated string used (\'layout.hbs\') `\n howdy`" },
+    { template: '1234', message: "Non-translated string used (\'layout.hbs\') `1234`" },
   ]
 });


### PR DESCRIPTION
See #58. The default configuration was changed to allow the following characters as bare strings: `(),.&+-=*/#%!?:[]{}`