### PR TITLE
Implement attribute checking for `bare-strings` rule.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,13 +74,19 @@ This rule forbids the following:
 <h2>Some string here!</h2>
 ```
 
-The following values are valid configuration:
+ The following values are valid configuration:
 
-  * boolean -- `true` for enabled / `false` for disabled
-  * array -- an array of whitelisted strings
+   * boolean -- `true` for enabled / `false` for disabled
+   * array -- an array of whitelisted strings
+   * object -- An object with the following keys:
+     * `whitelist` -- An array of whitelisted strings
+     * `globalAttributes` -- An array of attributes to check on every element.
+     * `elementAttributes` -- An object whose keys are tag names and value is an array of attributes to check for that tag name.
 
-By default, the following characters are whitelisted:
-`(),.&+-=*/#%!?:[]{}`
+When the config value of `true` is used the following configuration is used:
+ * `whitelist` - `(),.&+-=*/#%!?:[]{}`
+ * `globalAttributes` - `title`
+ * `elementAttributes` - `{ img: ['alt'], input: ['placeholder'] }`
 
 
 #### block-indentation

--- a/blueprints/ember-cli-template-lint/files/.template-lintrc.js
+++ b/blueprints/ember-cli-template-lint/files/.template-lintrc.js
@@ -2,7 +2,7 @@
 'use strict';
 
 module.exports = {
-  'bare-strings': ['(', ')', ',', '.', '&', '+', '-', '=', '*', '/', '#', '%', '!', '?', ':', '[', ']', '{', '}'],
+  'bare-strings': true,
   'block-indentation': 2,
   'html-comments': true,
   'nested-interactive': true,

--- a/ext/helpers/ast-node-info.js
+++ b/ext/helpers/ast-node-info.js
@@ -10,4 +10,12 @@ AstNodeInfo.isNonConfigurationHtmlComment = function(node) {
   return node.type === 'CommentStatement' && node.value.trim().indexOf('template-lint ') !== 0;
 };
 
+AstNodeInfo.isTextNode = function(node) {
+  return node.type === 'TextNode';
+};
+
+AstNodeInfo.isElementNode = function(node) {
+  return node.type === 'ElementNode';
+};
+
 module.exports = AstNodeInfo;

--- a/ext/plugins/lint-bare-strings.js
+++ b/ext/plugins/lint-bare-strings.js
@@ -127,8 +127,9 @@ module.exports = function(addonContext) {
     }
   };
 
-  LogStaticStrings.prototype._getBareString = function(string) {
+  LogStaticStrings.prototype._getBareString = function(_string) {
     var whitelist = this.config.whitelist;
+    var string = _string;
 
     if (whitelist) {
       for (var i = 0; i < whitelist.length; i++) {
@@ -140,7 +141,7 @@ module.exports = function(addonContext) {
       }
     }
 
-    return string.trim() !== '' ? string : null;
+    return string.trim() !== '' ? _string : null;
   };
 
   LogStaticStrings.prototype._checkNodeAndLog = function(node, additionalDescription, loc) {

--- a/ext/plugins/lint-bare-strings.js
+++ b/ext/plugins/lint-bare-strings.js
@@ -55,21 +55,26 @@ module.exports = function(addonContext) {
     this.log(warning);
   };
 
-  LogStaticStrings.prototype.detect = function(node) {
-    if (node.type !== 'TextNode') { return false;}
-
-    var string = node.chars;
+  LogStaticStrings.prototype._checkStringAgainstWhitelist = function(string) {
     var whitelist = Array.isArray(this.config) ? this.config : null;
 
     if (whitelist) {
       for (var i = 0; i < whitelist.length; i++) {
         var entry = whitelist[i];
 
-        string = string.replace(entry, '');
+        while (string.indexOf(entry) > -1) {
+          string = string.replace(entry, '');
+        }
       }
     }
 
     return string.trim() !== '';
+  };
+
+  LogStaticStrings.prototype.detect = function(node) {
+    if (node.type !== 'TextNode') { return false;}
+
+    return this._checkStringAgainstWhitelist(node.chars);
   };
 
   return LogStaticStrings;

--- a/node-tests/helpers/rule-test-harness.js
+++ b/node-tests/helpers/rule-test-harness.js
@@ -74,12 +74,13 @@ module.exports = function(options) {
 
     options.good.forEach(function(item) {
       var template = typeof item === 'object' ? item.template : item;
+      var testMethod = typeof item === 'object' && item.focus ? it.only : it;
 
-      it('passes when given `' + template + '`', function() {
+      testMethod('passes when given `' + template + '`', function() {
         if (typeof item === 'string') {
           compile(item);
         } else {
-          if (item.config) {
+          if (item.config !== undefined) {
             config[options.name] = item.config;
           }
 

--- a/node-tests/helpers/rule-test-harness.js
+++ b/node-tests/helpers/rule-test-harness.js
@@ -40,6 +40,7 @@ module.exports = function(options) {
 
     options.bad.forEach(function(badItem) {
       var testMethod = badItem.focus ? it.only : it;
+      var expectedMessages = badItem.messages || [badItem.message];
 
       testMethod('logs a message in the console when given `' + badItem.template + '`', function() {
         if (badItem.config) {
@@ -48,7 +49,7 @@ module.exports = function(options) {
 
         compile(badItem.template);
 
-        assert.deepEqual(messages, [badItem.message]);
+        assert.deepEqual(messages, expectedMessages);
       });
 
       it('passes with `' + badItem.template + '` when rule is disabled', function() {

--- a/node-tests/unit/plugins/lint-bare-strings-test.js
+++ b/node-tests/unit/plugins/lint-bare-strings-test.js
@@ -40,8 +40,8 @@ generateRuleTests({
     { template: '<div>\n  1234\n</div>', message: "Non-translated string used (\'layout.hbs\'@ L1:C5): `\n  1234\n`." },
 
     {
-      template: '<input placeholder="trolol">',
-      message: "Non-translated string used in `placeholder` attribute ('layout.hbs'@ L1:C8): `trolol`."
+      template: '<a title="hahaha trolol"></a>',
+      message: "Non-translated string used in `title` attribute ('layout.hbs'@ L1:C4): `hahaha trolol`."
     },
 
     {

--- a/node-tests/unit/plugins/lint-bare-strings-test.js
+++ b/node-tests/unit/plugins/lint-bare-strings-test.js
@@ -18,6 +18,10 @@ generateRuleTests({
       template: '\nfoo'
     },
     {
+      config: ['tarzan!'],
+      template: 'tarzan!\t\n  tarzan!'
+    },
+    {
       config: ['/', '"'],
       template: '{{t "foo"}} / "{{name}}"'
     },

--- a/node-tests/unit/plugins/lint-bare-strings-test.js
+++ b/node-tests/unit/plugins/lint-bare-strings-test.js
@@ -34,6 +34,20 @@ generateRuleTests({
 
   bad: [
     { template: '\n howdy', message: "Non-translated string used (\'layout.hbs\'@ L1:C0) `\n howdy`" },
-    { template: '<div>\n  1234\n</div>', message: "Non-translated string used (\'layout.hbs\'@ L1:C5) `\n  1234\n`" }
+    { template: '<div>\n  1234\n</div>', message: "Non-translated string used (\'layout.hbs\'@ L1:C5) `\n  1234\n`" },
+
+    {
+      template: '<input placeholder="trolol">',
+      message: "Non-translated string used ('layout.hbs'@ L1:C8) `trolol`"
+    },
+
+    {
+      // multiple bare strings are all logged
+      template: '<div>Bady\n  <input placeholder="trolol">\n</div>',
+      messages: [
+        "Non-translated string used (\'layout.hbs\'@ L1:C5) `Bady\n  `",
+        "Non-translated string used ('layout.hbs'@ L2:C10) `trolol`"
+      ]
+    }
   ]
 });

--- a/node-tests/unit/plugins/lint-bare-strings-test.js
+++ b/node-tests/unit/plugins/lint-bare-strings-test.js
@@ -5,15 +5,7 @@ var generateRuleTests = require('../../helpers/rule-test-harness');
 generateRuleTests({
   name: 'bare-strings',
 
-  config: {
-    whitelist: ['(', ')', ',', '.', '&', '+', '-', '=', '*', '/', '#', '%', '!', '?', ':', '[', ']', '{', '}'],
-
-    globalAttributes: [ 'title' ],
-    elementAttributes: {
-      'input': ['placeholder'],
-      'img': ['alt']
-    }
-  },
+  config: true,
 
   good: [
     '{{t "howdy"}}',

--- a/node-tests/unit/plugins/lint-bare-strings-test.js
+++ b/node-tests/unit/plugins/lint-bare-strings-test.js
@@ -29,24 +29,32 @@ generateRuleTests({
     '{{t "foo"}}, {{t "bar"}} ({{length}})',
     '(),.&+-=*/#%!?:[]{}',
     '<!-- template-lint bare-strings=false -->',
-    '<!-- template-lint enabled=false -->'
+    '<!-- template-lint enabled=false -->',
+
+    // placeholder is a <input> specific attribute
+    '<div placeholder="wat?"></div>'
   ],
 
   bad: [
-    { template: '\n howdy', message: "Non-translated string used (\'layout.hbs\'@ L1:C0) `\n howdy`" },
-    { template: '<div>\n  1234\n</div>', message: "Non-translated string used (\'layout.hbs\'@ L1:C5) `\n  1234\n`" },
+    { template: '\n howdy', message: "Non-translated string used (\'layout.hbs\'@ L1:C0): `\n howdy`." },
+    { template: '<div>\n  1234\n</div>', message: "Non-translated string used (\'layout.hbs\'@ L1:C5): `\n  1234\n`." },
 
     {
       template: '<input placeholder="trolol">',
-      message: "Non-translated string used ('layout.hbs'@ L1:C8) `trolol`"
+      message: "Non-translated string used in `placeholder` attribute ('layout.hbs'@ L1:C8): `trolol`."
+    },
+
+    {
+      template: '<input placeholder="trolol">',
+      message: "Non-translated string used in `placeholder` attribute ('layout.hbs'@ L1:C8): `trolol`."
     },
 
     {
       // multiple bare strings are all logged
       template: '<div>Bady\n  <input placeholder="trolol">\n</div>',
       messages: [
-        "Non-translated string used (\'layout.hbs\'@ L1:C5) `Bady\n  `",
-        "Non-translated string used ('layout.hbs'@ L2:C10) `trolol`"
+        "Non-translated string used (\'layout.hbs\'@ L1:C5): `Bady\n  `.",
+        "Non-translated string used in `placeholder` attribute ('layout.hbs'@ L2:C10): `trolol`."
       ]
     }
   ]

--- a/node-tests/unit/plugins/lint-bare-strings-test.js
+++ b/node-tests/unit/plugins/lint-bare-strings-test.js
@@ -5,7 +5,15 @@ var generateRuleTests = require('../../helpers/rule-test-harness');
 generateRuleTests({
   name: 'bare-strings',
 
-  config: ['(', ')', ',', '.', '&', '+', '-', '=', '*', '/', '#', '%', '!', '?', ':', '[', ']', '{', '}'],
+  config: {
+    whitelist: ['(', ')', ',', '.', '&', '+', '-', '=', '*', '/', '#', '%', '!', '?', ':', '[', ']', '{', '}'],
+
+    globalAttributes: [ 'title' ],
+    elementAttributes: {
+      'input': ['placeholder'],
+      'img': ['alt']
+    }
+  },
 
   good: [
     '{{t "howdy"}}',
@@ -32,7 +40,35 @@ generateRuleTests({
     '<!-- template-lint enabled=false -->',
 
     // placeholder is a <input> specific attribute
-    '<div placeholder="wat?"></div>'
+    '<div placeholder="wat?"></div>',
+
+    {
+      // config as array is whitelist of chars
+      config: ['/', '"'],
+      template: '{{t "foo"}} / "{{name}}"'
+    },
+
+    {
+      config: true,
+      template: '\n {{translate "greeting"}},'
+    },
+
+    {
+      config: false,
+      template: '\nfoobar'
+    },
+
+    {
+      // override the globalAttributes list
+      config: { globalAttributes: [] },
+      template: '<a title="hahaha trolol"></a>'
+    },
+
+    {
+      // override the elementAttributes list
+      config: { elementAttributes: { }},
+      template: '<input placeholder="hahaha">'
+    }
   ],
 
   bad: [
@@ -47,6 +83,18 @@ generateRuleTests({
     {
       template: '<input placeholder="trolol">',
       message: "Non-translated string used in `placeholder` attribute ('layout.hbs'@ L1:C8): `trolol`."
+    },
+
+    {
+      config: { globalAttributes: ['data-foo'] },
+      template: '<div data-foo="derpy"></div>',
+      message: "Non-translated string used in `data-foo` attribute ('layout.hbs'@ L1:C6): `derpy`."
+    },
+
+    {
+      config: { elementAttributes: { img: ['data-alt']} },
+      template: '<img data-alt="some alternate here">',
+      message: "Non-translated string used in `data-alt` attribute ('layout.hbs'@ L1:C6): `some alternate here`."
     },
 
     {


### PR DESCRIPTION
These changes update the `bare-strings` rule to allow the following configuration:

   * boolean -- `true` for enabled / `false` for disabled
   * array -- an array of whitelisted strings
   * object -- An object with the following keys:
     * `whitelist` -- An array of whitelisted strings
     * `globalAttributes` -- An array of attributes to check on every element.
     * `elementAttributes` -- An object whose keys are tag names and value is an array of attributes to check for that tag name.

We have also update the default blueprinted value to be `true`, which defaults the configuration to:

```js
{
  whitelist: ['(', ')', ',', '.', '&', '+', '-', '=', '*', '/', '#', '%', '!', '?', ':', '[', ']', '{', '}'],
  globalAttributes: GLOBAL_ATTRIBUTES,
  elementAttributes: TAG_ATTRIBUTES
};
```