### PR TITLE
Add rule lint-quotes (DON'T MERGE)

### DIFF
--- a/ext/plugins/index.js
+++ b/ext/plugins/index.js
@@ -7,5 +7,6 @@ module.exports = {
   'triple-curlies': require('./lint-triple-curlies'),
   'lint-self-closing-void-elements': require('./lint-self-closing-void-elements'),
   'nested-interactive': require('./lint-nested-interactive'),
+  'quotes': require('./lint-quotes'),
   'deprecated-each-syntax': require('./deprecations/lint-deprecated-each-syntax')
 };

--- a/ext/plugins/lint-quotes.js
+++ b/ext/plugins/lint-quotes.js
@@ -1,0 +1,90 @@
+'use strict';
+
+/*
+ Enforce quotes style
+
+ ```
+ {{! good }}
+ <img alt="tomster" src="tomster.jpg">
+
+ {{! bad}}
+ <img alt='tomster' src="tomster.jpg">
+ ```
+
+ The following values are valid configuration:
+
+   * boolean -- `false` for disabled
+   * string -- `single` of `double` for enforce style
+ */
+
+var calculateLocationDisplay = require('../helpers/calculate-location-display');
+var buildPlugin = require('./base');
+
+var SINGLE_QUOTES_NAME = 'single';
+var DOUBLE_QUOTES_NAME = 'double';
+
+module.exports = function(addonContext) {
+  var LogQuotes = buildPlugin(addonContext, 'quotes');
+
+  LogQuotes.prototype.parseConfig = function(config) {
+    if (config === false || config === undefined) {
+      return false;
+    }
+
+    if (config === SINGLE_QUOTES_NAME || config === DOUBLE_QUOTES_NAME) {
+      return {
+        quotesType: config,
+        quoteCharacter: config === SINGLE_QUOTES_NAME ? "'" : '"'
+      };
+    }
+
+    var errorMessage = 'The quotes rule accepts one of the following values.\n ' +
+      '  * boolean -- `false` to disable\n' +
+      '  * string -- `' + SINGLE_QUOTES_NAME + '` of `' + DOUBLE_QUOTES_NAME +'` for enforce style\n' +
+      '\nYou specified `' + JSON.stringify(config) + '`';
+
+    throw new Error(errorMessage);
+  };
+
+  LogQuotes.prototype.detect = function(node) {
+    return (
+      node.type === 'ElementNode' &&
+      node.attributes.length > 0
+    );
+  };
+
+  function filterAttribute(attribute) {
+    return (
+      attribute.value.type === 'TextNode' &&
+      attribute.value.chars.length > 0
+    );
+  }
+
+  LogQuotes.prototype._processAttribute = function(attribute) {
+    var source = this.sourceForNode(attribute);
+    var qouteCharacter = source[source.length - 1];
+
+    if (this.config.quoteCharacter === qouteCharacter) {
+      return;
+    }
+
+    var undesiredQouteStyle = (
+      this.config.quotesType === SINGLE_QUOTES_NAME ?
+        DOUBLE_QUOTES_NAME :
+        SINGLE_QUOTES_NAME
+    );
+
+    var errorMessage = 'Quotes: you got ' + undesiredQouteStyle +
+      ' qoutes for an attribute instead of ' + this.config.quotesType +
+      ' qoutes ' + calculateLocationDisplay(this.options.moduleName, attribute.loc.start);
+    this.log(errorMessage);
+  };
+
+  LogQuotes.prototype.process = function(node) {
+    node.attributes
+      .filter(filterAttribute)
+      .forEach(this._processAttribute, this);
+  };
+
+  return LogQuotes;
+};

--- a/node-tests/unit/plugins/lint-quotes-test.js
+++ b/node-tests/unit/plugins/lint-quotes-test.js
@@ -7,6 +7,9 @@ generateRuleTests({
 
   good: [
     {
+      config: true,
+      template: '<img alt=\'tomster\' src="tomster.png">'
+    }, {
       config: 'double',
       template: '<img alt="tomster" src="tomster.png">'
     }, {
@@ -24,6 +27,10 @@ generateRuleTests({
 
   bad: [
     {
+      config: true,
+      template: '<img alt=tomster>',
+      message: "Quotes: you should use qoutes for HTML attributes (\'layout.hbs\'@ L1:C6)"
+    }, {
       config: 'double',
       template: "<img alt='tomster'>",
       message: "Quotes: you got single qoutes for an attribute instead of double qoutes (\'layout.hbs\'@ L1:C6)"

--- a/node-tests/unit/plugins/lint-quotes-test.js
+++ b/node-tests/unit/plugins/lint-quotes-test.js
@@ -1,0 +1,36 @@
+'use strict';
+
+var generateRuleTests = require('../../helpers/rule-test-harness');
+
+generateRuleTests({
+  name: 'quotes',
+
+  good: [
+    {
+      config: 'double',
+      template: '<img alt="tomster" src="tomster.png">'
+    }, {
+      config: 'single',
+      template: "<img alt='tomster' src='tomster.png'>"
+    }, {
+      config: 'double',
+      template: '<img alt src="tomster.png">'
+    // TODO:
+    // }, {
+    //   config: 'double',
+    //   template: '<img alt src=tomster.png>'
+    }
+  ],
+
+  bad: [
+    {
+      config: 'double',
+      template: "<img alt='tomster'>",
+      message: "Quotes: you got single qoutes for an attribute instead of double qoutes (\'layout.hbs\'@ L1:C6)"
+    }, {
+      config: 'single',
+      template: '<img alt="tomster">',
+      message: "Quotes: you got double qoutes for an attribute instead of single qoutes (\'layout.hbs\'@ L1:C6)"
+    }
+  ]
+});


### PR DESCRIPTION
#### config:
- `false` - disable
- `true` - only require qoutes for HTML attributes 
- `"single"` - always single quotes
- `"double"` - always double quotes
- `["single", "avoidEscape"]` - prefer single quotes unless there is an escape needed only to single quotes
- `["double", "avoidEscape"]` - prefer double quotes unless there is an escape needed only to double quotes

#### todos: 
- [x] adding support for HTML attributes
- [ ] adding support for HTMLBars helper attributes
- [x] adding support for only requiring qoutes
- [ ] adding README / and to blueprints
- [ ] adding avoidEscape supports
- [ ] adding avoidEscape to README

if i miss something, please tell me
