### PR TITLE
Update print-failing command to emit rule specific stuff.

### DIFF
--- a/lib/commands/print-failing.js
+++ b/lib/commands/print-failing.js
@@ -32,8 +32,16 @@ module.exports = {
         moduleId: moduleId
       });
 
-      if (errors.length > 0) {
-        templatesWithErrors.push(moduleId);
+      var failingRules = errors.reduce(function(memo, error) {
+        if (memo.indexOf(error.rule) === -1) {
+          memo.push(error.rule);
+        }
+
+        return memo;
+      }, []);
+
+      if (failingRules.length > 0) {
+        templatesWithErrors.push({ moduleId: moduleId, only: failingRules });
       }
     });
 

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "debug": "^2.2.0",
     "ember-cli-babel": "^5.1.6",
     "ember-cli-version-checker": "^1.1.6",
-    "ember-template-lint": "^0.5.9",
+    "ember-template-lint": "^0.5.10",
     "exists-sync": "0.0.3",
     "hash-for-dep": "^1.0.2",
     "js-string-escape": "^1.0.0",


### PR DESCRIPTION
Now emits the following output:

```
Add the following to your `.tempate-lintrc.js` file to mark these files as pending.


pending: [
  {
    "moduleId": "sample-2-4-0/templates/application",
    "only": [
      "bare-strings"
    ]
  }
]
```