### PR TITLE
Add space to error message

### DIFF
--- a/broccoli-template-linter.js
+++ b/broccoli-template-linter.js
@@ -72,7 +72,7 @@ TemplateLinter.prototype.build = function () {
 };
 
 TemplateLinter.prototype.convertErrorToDisplayMessage = function(error) {
-  var message = error.rule + ': ' + error.message + '(' + error.moduleId;
+  var message = error.rule + ': ' + error.message + ' (' + error.moduleId;
 
   if (error.line && error.column) {
     message = message + ' @ L' + error.line + ':C' + error.column;


### PR DESCRIPTION
Seeing error messages like:

```
invalid-interactive: Interaction added to non-interactive element(dummy/templates/application @ L166:C35):
`<li><button class="button" {{action "reload"}}>Hard Reload</button></li>`
```