### PR TITLE
added `baseDir` for caching purposes

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,10 @@ module.exports = {
 
     registry.add('htmlbars-ast-plugin', {
       name: 'remove-configuration-html-comments',
-      plugin: RemoveConfigurationHtmlComments()
+      plugin: RemoveConfigurationHtmlComments(),
+      baseDir: function() {
+        return __dirname;
+      }
     });
   }
 };


### PR DESCRIPTION
fixes https://github.com/rwjblue/ember-cli-template-lint/issues/147

**before:**

<img width="816" alt="screen shot 2016-08-12 at 13 24 10" src="https://cloud.githubusercontent.com/assets/2526/17622423/3885a26a-6092-11e6-9571-1e078ef16e04.png">

**after:**

<img width="751" alt="screen shot 2016-08-12 at 13 39 16" src="https://cloud.githubusercontent.com/assets/2526/17622431/402c4762-6092-11e6-866a-fb98e7d7cee2.png">

