### PR TITLE
Fix console using ui.writeLine

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ module.exports = {
         annotation: 'TemplateLinter',
         templatercPath: this.project.root + '/.template-lintrc',
         generateTestFile: this.project.generateTestFile,
-        _console: mockConsole,
+        console: mockConsole,
         project: this.project
       });
     }


### PR DESCRIPTION
Currently console output is using the native console instead of ember-cli's `ui` object, breaking CI runs when using the `--silent` flag and piping test output to an XUnit file. This is happening probably accidentally as the necessary code is there. It's just `index.js` setting the option as `_console` while `broccoli-template-linter.js` expects it as `console`.