### PR TITLE
Update to use common extension for template linting.

### DIFF
--- a/broccoli-template-linter.js
+++ b/broccoli-template-linter.js
@@ -42,7 +42,7 @@ TemplateLinter.prototype = Object.create(Filter.prototype);
 TemplateLinter.prototype.constructor = TemplateLinter;
 
 TemplateLinter.prototype.extensions = ['hbs'];
-TemplateLinter.prototype.targetExtension = 'template-lint-test.js';
+TemplateLinter.prototype.targetExtension = 'template.lint-test.js';
 
 TemplateLinter.prototype.baseDir = function() {
   return __dirname;

--- a/node-tests/acceptance/broccoli-test.js
+++ b/node-tests/acceptance/broccoli-test.js
@@ -55,7 +55,7 @@ describe('broccoli-template-linter', function() {
       .then(function(results) {
         var outputPath = results.directory;
         var contents = fs.readFileSync(
-          path.join(outputPath, 'templates', 'application.template-lint-test.js'),
+          path.join(outputPath, 'templates', 'application.template.lint-test.js'),
           { encoding: 'utf8' }
         );
 
@@ -75,7 +75,7 @@ describe('broccoli-template-linter', function() {
       .then(function(results) {
         var outputPath = results.directory;
         var contents = fs.readFileSync(
-          path.join(outputPath, 'templates', 'application.template-lint-test.js'),
+          path.join(outputPath, 'templates', 'application.template.lint-test.js'),
           { encoding: 'utf8' }
         );
 


### PR DESCRIPTION
Prior to this change the test files emitted from ember-cli-template-lint would not be disabled by the "no lint" checkbox in ember-cli's default test harness.

---

Without "Disable Linting" checked:

![screenshot](https://monosnap.com/file/2iJWWxKco9dX66CXrT9RztwKKR4eEx.png)

With "Disable Linting" checked:

![screenshot](https://monosnap.com/file/DgjttPHf02OLOrgiFZU8GL0fwnteqb.png)