### PR TITLE
Update ember-cli-blueprint-test-helpers and fix tests

### DIFF
--- a/node-tests/blueprints/ember-cli-template-lint-test.js
+++ b/node-tests/blueprints/ember-cli-template-lint-test.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var fs = require('fs');
 var blueprintHelpers = require('ember-cli-blueprint-test-helpers/helpers');
 var setupTestHooks = blueprintHelpers.setupTestHooks;
 var emberNew = blueprintHelpers.emberNew;
@@ -21,8 +20,6 @@ describe('Acceptance: ember generate and destroy ember-cli-template-lint', funct
   after(function() {
     delete process.env.EMBER_DATA_SKIP_VERSION_CHECKING_DO_NOT_USE_THIS_ENV_VARIABLE;
     delete process.env.FORCE_LOCALIZED_FOR_TESTING;
-
-    fs.unlinkSync('node_modules/ember-cli-template-lint');
   });
 
   it('ember-cli-template-lint without localization framework', function() {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "ember-ajax": "2.5.1",
     "ember-cli": "2.6.2",
     "ember-cli-app-version": "^2.0.0",
-    "ember-cli-blueprint-test-helpers": "^0.13.1",
+    "ember-cli-blueprint-test-helpers": "^0.17.2",
     "ember-cli-dependency-checker": "^1.2.0",
     "ember-cli-htmlbars": "^1.0.6",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",


### PR DESCRIPTION
Here is the fix for the failing greenkeeper update #221 