### PR TITLE
fix addon not working when `yarn link`ed

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ module.exports = {
 
     if (!('testGenerator' in this._options)) {
       let VersionChecker = require('ember-cli-version-checker');
-      let checker = new VersionChecker(this);
+      let checker = new VersionChecker(this.project);
 
       if (checker.for('ember-cli-qunit', 'npm').satisfies('*')) {
         this._options.testGenerator = 'qunit';


### PR DESCRIPTION
When I `yarn link`ed the addon to develop, the addon detected my app's tests as being qunit instead of mocha, and so the addon didn't generate any tests