### PR TITLE
Prevent empty errors

### DIFF
--- a/broccoli-template-linter.js
+++ b/broccoli-template-linter.js
@@ -121,7 +121,9 @@ TemplateLinter.prototype.processString = function(contents, relativePath) {
 };
 
 TemplateLinter.prototype.postProcess = function(results) {
-  this._errors.push(results.consoleOutput);
+  if (results.consoleOutput) {
+    this._errors.push(results.consoleOutput);
+  }
 
   return results;
 };


### PR DESCRIPTION
@rwjblue 
This fix should prevent adding empty or null errors to errors array.
Before:
```js
['','','','','error',] // self._errors
```
After
```js
['error'] // self._errors
```
It will fix an issue with inproper fomratting and counting. #273 